### PR TITLE
Add ability to define indent

### DIFF
--- a/src/RssWriter.php
+++ b/src/RssWriter.php
@@ -32,15 +32,30 @@ class RssWriter
     private $flushEarly = false;
 
     /**
-     * @param \XmlWriter $xmlWriter
-     * @param array      $writers   An array of instances implementing WriterRegistererInterface
+     * @var bool
      */
-    public function __construct(\XmlWriter $xmlWriter = null, array $writers = [])
+    private $xmlIndent;
+
+    /**
+     * @var string
+     */
+    private $xmlIndentString;
+
+    /**
+     * @param \XmlWriter $xmlWriter
+     * @param array      $writers      An array of instances implementing WriterRegistererInterface
+     * @param bool       $indent       Toggle indentation on/off
+     * @param string     $indentString Set string used for indenting
+     */
+    public function __construct(\XmlWriter $xmlWriter = null, array $writers = [], $indent = false, $indentString = ' ')
     {
         if ($xmlWriter === null) {
             $xmlWriter = new \XmlWriter();
             $xmlWriter->openMemory();
         }
+
+        $this->xmlIndent = $indent;
+        $this->xmlIndentString = $indentString;
 
         $this->xmlWriter = $xmlWriter;
         foreach ($writers as $writer) {
@@ -64,12 +79,15 @@ class RssWriter
      *
      * @param Channel $channel
      *
-     * @return mixed Similar to XMLWriter::flush 
+     * @return mixed Similar to XMLWriter::flush
      *
      * @see http://php.net/manual/function.xmlwriter-flush.php
      */
     public function writeChannel(Channel $channel)
     {
+        $this->xmlWriter->setIndent($this->xmlIndent);
+        $this->xmlWriter->setIndentString($this->xmlIndentString);
+
         $this->xmlWriter->startDocument();
         if ($this->flushEarly) {
             $this->xmlWriter->flush();

--- a/tests/Extension/Itunes/ItunesWriterTest.php
+++ b/tests/Extension/Itunes/ItunesWriterTest.php
@@ -20,7 +20,6 @@ class ItunesWriterTest extends \PHPUnit_Framework_TestCase
     public function testWriteChannel()
     {
         $rssWriter = new RssWriter();
-        $rssWriter->getXmlWriter()->setIndent(false);
         $writer = new ItunesWriter();
 
         $channel = new ItunesChannel();

--- a/tests/RssWriterTest.php
+++ b/tests/RssWriterTest.php
@@ -27,8 +27,7 @@ class RssWriterTest extends \PHPUnit_Framework_TestCase
 {
     public function testRssWriter()
     {
-        $rssWriter = new RssWriter();
-        $rssWriter->getXmlWriter()->setIndent(true);
+        $rssWriter = new RssWriter(null, [], true);
         $rssWriter->registerWriter(new CoreWriter());
         $rssWriter->registerWriter(new ItunesWriter());
         $rssWriter->registerWriter(new SyWriter());


### PR DESCRIPTION
I started to wondering what could be the best way to enable and define indentation for a xml.
The best place seemed to be in RssWriter:

```diff
--- a/src/RssWriter.php
+++ b/src/RssWriter.php
    public function writeChannel(Channel $channel)
    {
+       $this->xmlWriter->setIndent(true);
+       $this->xmlWriter->setIndentString('    ');
+
        $this->xmlWriter->startDocument();
```

But this'll force every RSS to be indented without being able to turn it off (to keep default behavior).

I've tried many other option in RssWriter:
- define proxies methods (`setXmlWriterIndent` & `setXmlWriterIndentString`)
- add extra parameters in construct `$indent = false, $indentString = ''` and use it when the parameter `$xmlWriter` is null

But all these options are useless since the `RssStreamedResponse` construct redefine the "open" method (using `$this->rssWriter->getXmlWriter()->openUri('php://output');`). This erase all previous defined indentation.

The only solution seems to be to add these extra parameters in the constructor with default value and set indent right before `startDocument`.

What do you think?
